### PR TITLE
metautils : recent headers now installed too

### DIFF
--- a/metautils/lib/CMakeLists.txt
+++ b/metautils/lib/CMakeLists.txt
@@ -472,6 +472,8 @@ install(FILES
 			test_addr.h
 			tree.h
 			volume_lock.h
+			notifications.h
+			meta_backend_common.h
 		DESTINATION include/metautils/lib
 		PERMISSIONS
 			OWNER_WRITE OWNER_READ GROUP_READ WORLD_READ)


### PR DESCRIPTION
Before this commit, it was not possible to compile the metacd-http.
Because the two newly-installed files were included from the main metautils header.

Change-Id: I241699ae0ecd8f68be28386b0659f2cd6068e66d
