### PR TITLE
sqlx_service: an URL can now be announced, different from bind URL

### DIFF
--- a/metautils/lib/metautils_resolv.h
+++ b/metautils/lib/metautils_resolv.h
@@ -133,7 +133,11 @@ struct addr_info_s *build_addr_info(const gchar * ip, int port, GError ** err);
 
 gboolean metautils_addr_valid_for_connect(const struct addr_info_s *a);
 
+gboolean metautils_addr_valid_for_bind(const struct addr_info_s *a);
+
 gboolean metautils_url_valid_for_connect(const gchar *url);
+
+gboolean metautils_url_valid_for_bind(const gchar *url);
 
 /** @} */
 

--- a/metautils/lib/utils_addr_info.c
+++ b/metautils/lib/utils_addr_info.c
@@ -15,8 +15,18 @@
 #include "metacomm.h"
 
 gboolean
+metautils_addr_valid_for_bind(const struct addr_info_s *a)
+{
+	/* @todo TODO we should check the address is not broadcast (local
+	 * or global), not multicast, not network address, etc. */
+	return a->port != 0;
+}
+
+gboolean
 metautils_addr_valid_for_connect(const struct addr_info_s *a)
 {
+	/* @todo TODO we should check the address is not broadcast (local
+	 * or global), not multicast, not network address, etc. */
 	return a->port != 0 && !data_is_zeroed(&(a->addr), sizeof(a->addr));
 }
 
@@ -32,6 +42,20 @@ metautils_url_valid_for_connect(const gchar *url)
 	if (!grid_string_to_addrinfo(url, NULL, &ai))
 		return FALSE;
 	return metautils_addr_valid_for_connect(&ai);
+}
+
+gboolean
+metautils_url_valid_for_bind(const gchar *url)
+{
+	if (NULL == url) {
+		errno = EINVAL;
+		return FALSE;
+	}
+	addr_info_t ai;
+	memset(&ai, 0, sizeof(ai));
+	if (!grid_string_to_addrinfo(url, NULL, &ai))
+		return FALSE;
+	return metautils_addr_valid_for_bind(&ai);
 }
 
 gint

--- a/sqlx/sqlx_service.h
+++ b/sqlx/sqlx_service.h
@@ -50,6 +50,7 @@ struct sqlx_service_s
 	const struct sqlx_service_config_s *service_config;
 
 	GString *url;
+	GString *announce;
 	gchar *zk_url;
 
 	struct sqlx_repository_s *repository;


### PR DESCRIPTION
In addition, checks have been added on the URL provided.

Change-Id: Ib21f8d07c2224385df2c515fc43a22e0cd5a415c
