### PR TITLE
{svc,rawx}-monitor now transmit their environment

### DIFF
--- a/rawx-apache2/httpd.conf.sample
+++ b/rawx-apache2/httpd.conf.sample
@@ -1,5 +1,9 @@
-LoadModule dav_module        /usr/local/oss/apache2-2.2.9/modules/mod_dav.so
-LoadModule dav_rawx_module   /usr/local/oss/apache2-2.2.9/modules/mod_dav_rawx.so
+# For httpd 2.4
+LoadModule mpm_worker_module modules/mod_mpm_worker.so
+LoadModule unixd_module      modules/mod_unixd.so
+
+LoadModule dav_module        modules/mod_dav.so
+LoadModule dav_rawx_module   modules/mod_dav_rawx.so
 #LoadModule log_config_module /usr/local/oss/apache2-2.2.9/modules/mod_log_config.so
 
 Listen 127.0.0.1:9000

--- a/rawx-monitor/rawx-monitor.conf
+++ b/rawx-monitor/rawx-monitor.conf
@@ -19,7 +19,7 @@ pidfile=/GRID/TEST/common/run/rawx-monitor-1.pid
 # will only register the service, it is not responsible of the services's
 # status.
 [Child]
-command=/usr/local/oss/apache2/bin/httpd.worker -D FOREGROUND -f /GRID/TEST/common/conf/rawx-1/conf/httpd.conf
+command=/usr/sbin/httpd -D FOREGROUND -f /GRID/TEST/common/conf/rawx-1/conf/httpd.conf
 respawn=false
 rlimit.stack_size=1048576
 rlimit.core_size=-1

--- a/rawx-monitor/src/main.c
+++ b/rawx-monitor/src/main.c
@@ -26,6 +26,8 @@
 #include <metautils/lib/metacomm.h>
 #include <cluster/lib/gridcluster.h>
 
+#include <svc-monitor/src/utils.h>
+
 #include "filer_monitor.h"
 #ifdef HAVE_NETAPP
 # include "netapp.h"
@@ -570,6 +572,7 @@ _cfg_section_child(GKeyFile *kf, const gchar *section, GError **error)
 	supervisor_children_status(CHILD_KEY, 1);
 	supervisor_children_set_respawn(CHILD_KEY, 0);
 	supervisor_children_set_delay(CHILD_KEY, 0);
+	supervisor_preserve_env(CHILD_KEY);
 
 	/* Should the rawx-monitor make the Service respawn ?
 	 * Default : NO ! Remember the rawx-monitor will exit

--- a/svc-monitor/src/main.c
+++ b/svc-monitor/src/main.c
@@ -21,6 +21,8 @@
 #include <metautils/lib/metautils.h>
 #include <cluster/lib/gridcluster.h>
 
+#include <svc-monitor/src/utils.h>
+
 #define CHILD_KEY "SVC"
 #define DEFAULT_MONITOR_PERIOD 10
 
@@ -347,6 +349,7 @@ main(int argc, char ** argv)
 
 	supervisor_children_set_respawn(CHILD_KEY, FALSE);
 	supervisor_children_set_working_directory(CHILD_KEY, "/tmp");
+	supervisor_preserve_env(CHILD_KEY);
 
 	service = g_malloc0(sizeof(service_info_t));
 	if (0 != init_srvinfo(svc_id, service)) {

--- a/svc-monitor/src/utils.h
+++ b/svc-monitor/src/utils.h
@@ -1,0 +1,20 @@
+#ifndef RC_SVCMONITOR_utils_h
+#define RC_SVCMONITOR_utils_h 1
+
+/** @file Extension to the gridinit-utils library.
+ * Not destined to be installed.
+ */
+
+// Used in rawx-monitor and svc-monitor
+static inline void
+supervisor_preserve_env (const gchar *child)
+{
+	gchar **keys = g_listenv();
+	if (!keys)
+		return;
+	for (gchar **pk = keys; *pk ;++pk)
+		supervisor_children_setenv(child, *pk, g_getenv(*pk));
+	g_strfreev(keys);
+}
+
+#endif // RC_SVCMONITOR_utils_h


### PR DESCRIPTION
This is necessary to install RC in non-stardard places, thus working with variables such as PATH and LD_LIBRARY_PATH.

In addition, the sample configurations have been adapted to fit decently recent httpd versions (i.e. 2.4).

Change-Id: I26960cc38d35de919c513a3be220e24648f25362
