### PR TITLE
Several fixes and improvements

### DIFF
--- a/meta2v2/meta2_filters_action_events.c
+++ b/meta2v2/meta2_filters_action_events.c
@@ -176,7 +176,7 @@ touch_v2_content(struct meta2_backend_s *m2b, struct hc_url_s *url,
 	struct event_config_s *evt_config = meta2_backend_get_event_config(m2b,
 			hc_url_get(url, HCURL_NS));
 
-	GRID_INFO("Touch v2 content");
+	GRID_DEBUG("Touch v2 content [%s]", hc_url_get(url, HCURL_WHOLE));
 
 	event = _build_event(m2b, evt_type, url);
 
@@ -187,7 +187,7 @@ touch_v2_content(struct meta2_backend_s *m2b, struct hc_url_s *url,
 			goto error;
 
 		if (!(v1 = meta2_raw_content_v2_get_v1(v2, NULL)))
-			WARN("V2 to V1 mapping error");
+			GRID_WARN("V2 to V1 mapping error");
 		else {
 			err = _meta2_event_add_raw_v1(event, v1);
 			meta2_maintenance_destroy_content(v1);
@@ -196,11 +196,8 @@ touch_v2_content(struct meta2_backend_s *m2b, struct hc_url_s *url,
 		}
 	}
 
-	if (event_get_dir(evt_config)) {
-		GRID_INFO("writing event");
+	if (event_get_dir(evt_config))
 		err = gridcluster_event_SaveNewEvent(evt_config, event);
-		//err = event_write(evt_config, event);
-	}
 
 error:
 	g_hash_table_destroy(event);
@@ -219,7 +216,7 @@ touch_v2_content_chunkonly(struct meta2_backend_s *m2b, struct hc_url_s *url,
 			hc_url_get(url, HCURL_NS));
 	const gchar* m2url = meta2_backend_get_local_addr(m2b);
 
-	GRID_INFO("Touch v2 content");
+	GRID_DEBUG("Touch v2 content [%s]", hc_url_get(url, HCURL_WHOLE));
 
 	event = _build_event(m2b, evt_type, url);
 
@@ -232,10 +229,8 @@ touch_v2_content_chunkonly(struct meta2_backend_s *m2b, struct hc_url_s *url,
 	if (m2url)
 		gridcluster_event_add_string(event, META2_EVTFIELD_M2ADDR, m2url);
 
-	if (event_get_dir(evt_config)) {
-		GRID_INFO("writing event");
+	if (event_get_dir(evt_config))
 		err = gridcluster_event_SaveNewEvent(evt_config, event);
-	}
 
 error:
 	g_hash_table_destroy(event);

--- a/meta2v2/meta2v2_remote.c
+++ b/meta2v2/meta2v2_remote.c
@@ -50,6 +50,8 @@ _m2v2_build_request(const gchar *name, GByteArray *sid,
 				metautils_gba_from_string(hc_url_get(url, HCURL_NS))),
 			"CONTAINER_ID", gba_poolify(&pool,
 				_url_2_gba(url)),
+			"CONTENT_PATH", gba_poolify(&pool, metautils_gba_from_string(
+					hc_url_get(url, HCURL_PATH))),
 			NULL);
 	GBA_POOL_CLEAN(pool);
 

--- a/metautils/lib/utils_service_info.c
+++ b/metautils/lib/utils_service_info.c
@@ -784,7 +784,7 @@ service_info_load_json_object(struct json_object *obj,
 	struct json_object *ns, *type, *url, *score, *tags;
 	if (!json_object_object_get_ex(obj, "ns", &ns)
 		|| !json_object_object_get_ex(obj, "type", &type)
-		|| !json_object_object_get_ex(obj, "url", &url)
+		|| !json_object_object_get_ex(obj, "addr", &url)
 		|| !json_object_object_get_ex(obj, "score", &score))
 		return NEWERROR(400, "Missing field");
 	if (!json_object_is_type(ns, json_type_string)

--- a/resolver/hc_resolver.c
+++ b/resolver/hc_resolver.c
@@ -454,15 +454,13 @@ hc_resolve_reference_service(struct hc_resolver_s *r, struct hc_url_s *url,
 }
 
 void
-hc_decache_reference_service(struct hc_resolver_s *r, struct hc_url_s *url,
-		const gchar *srvtype)
+hc_decache_reference(struct hc_resolver_s *r, struct hc_url_s *url)
 {
 	struct hashstr_s *hk;
 
-	GRID_TRACE2("%s(%s,%s)", __FUNCTION__, hc_url_get(url, HCURL_WHOLE), srvtype);
+	GRID_TRACE2("%s(%s)", __FUNCTION__, hc_url_get(url, HCURL_WHOLE));
 	g_assert(r != NULL);
 	g_assert(url != NULL);
-	g_assert(srvtype != NULL);
 
 	if (r->flags & HC_RESOLVER_NOCACHE)
 		return;
@@ -475,6 +473,21 @@ hc_decache_reference_service(struct hc_resolver_s *r, struct hc_url_s *url,
 			hc_url_get(url, HCURL_HEXID));
 	hc_resolver_forget(r, r->csm0.cache, hk);
 	g_free(hk);
+}
+
+void
+hc_decache_reference_service(struct hc_resolver_s *r, struct hc_url_s *url,
+		const gchar *srvtype)
+{
+	struct hashstr_s *hk;
+
+	GRID_TRACE2("%s(%s,%s)", __FUNCTION__, hc_url_get(url, HCURL_WHOLE), srvtype);
+	g_assert(r != NULL);
+	g_assert(url != NULL);
+	g_assert(srvtype != NULL);
+
+	if (r->flags & HC_RESOLVER_NOCACHE)
+		return;
 
 	hk = hashstr_printf("%s|%s|%s", srvtype,
 			hc_url_get(url, HCURL_NSPHYS),

--- a/resolver/hc_resolver.h
+++ b/resolver/hc_resolver.h
@@ -64,14 +64,14 @@ GError* hc_resolve_reference_service(struct hc_resolver_s *r,
 GError* hc_resolve_reference_directory(struct hc_resolver_s *r,
 		struct hc_url_s *url, gchar ***result);
 
-/**
- * @param r
- * @param url
- * @param srvtype
- */
+// Removes from the cache the services associated to the given references.
+// It doesn't touch the directory services belonging to the reference.
 void hc_decache_reference_service(struct hc_resolver_s *r,
 		struct hc_url_s *url, const gchar *srvtype);
 
+// Removes from the cache the directory services for the given references.
+// It doesn't touche the cache entries for the directory content.
+void hc_decache_reference(struct hc_resolver_s *r, struct hc_url_s *url);
 
 struct hc_resolver_stats_s
 {

--- a/server/CMakeLists.txt
+++ b/server/CMakeLists.txt
@@ -54,6 +54,7 @@ install(FILES
 			slab.h
 			transport_gridd.h
 			transport_http.h
+			stats_holder.h
 		DESTINATION include/server
 		PERMISSIONS
 			OWNER_WRITE OWNER_READ GROUP_READ WORLD_READ)


### PR DESCRIPTION
JSON fixed for service_info. Necessary for metacd-http
Finer decache in resolver. Idem, necessary for metacd-http.
m2v2_remote_touch_content fixed. Idem, necessary for metacd-http.
m2v2 does not generates events when disabled, and verbosity lowered.

Change-Id: Ib145ba973ad7d9f3810c4c0fa4f30f1be1ff4639
