### PR TITLE
Finer gauges for active threads, reliable accesslog delays

### DIFF
--- a/server/stats_holder.c
+++ b/server/stats_holder.c
@@ -207,26 +207,34 @@ grid_stats_holder_increment_merge(struct grid_stats_holder_s *base,
 
 /* ------------------------------------------------------------------------- */
 
+enum {
+	/*! If set, when there is no activity, the untouched slots are filled
+	 * with zeros. If not set (default), the previous value is repeated. */
+	RRD_FLAG_SHIFT_SET = 0x01,
+};
+
 struct grid_single_rrd_s
 {
 	time_t last;
 	time_t period;
+	guint32 flags;
+	guint64 def;
 	guint64 l0[];
 };
 
 struct grid_single_rrd_s*
-grid_single_rrd_create(time_t period)
+grid_single_rrd_create(time_t now, time_t period)
 {
-	struct grid_single_rrd_s *result;
+	struct grid_single_rrd_s *gsr;
 
 	EXTRA_ASSERT(period > 1);
 
-	result = g_malloc0(sizeof(struct grid_single_rrd_s)
+	gsr = g_malloc0(sizeof(struct grid_single_rrd_s)
 			+ (period * sizeof(guint64)));
-	result->last = time(0);
-	result->period = period;
+	gsr->last = now;
+	gsr->period = period;
 
-	return result;
+	return gsr;
 }
 
 void
@@ -236,74 +244,125 @@ grid_single_rrd_destroy(struct grid_single_rrd_s *gsr)
 		g_free(gsr);
 }
 
+void
+grid_single_rrd_set_default(struct grid_single_rrd_s *gsr, guint64 v)
+{
+	gsr->def = v;
+	gsr->flags |= RRD_FLAG_SHIFT_SET;
+}
+
+static inline void
+_rrd_set(struct grid_single_rrd_s *gsr, guint64 v)
+{
+	gsr->l0[gsr->last % gsr->period] = v;
+}
+
+static inline guint64
+_rrd_get(struct grid_single_rrd_s *gsr, time_t at)
+{
+	return gsr->l0[at % gsr->period];
+}
+
+static inline guint64
+_rrd_current(struct grid_single_rrd_s *gsr)
+{
+	return _rrd_get(gsr, gsr->last);
+}
+
+static guint64
+_rrd_past(struct grid_single_rrd_s *gsr, time_t period)
+{
+	return _rrd_get(gsr, gsr->last - period);
+}
+
 static void
-_gsr_blank_empty_slots(struct grid_single_rrd_s *gsr, guint64 v, time_t now)
+_gsr_manage_timeshift(struct grid_single_rrd_s *gsr, time_t now)
 {
-	time_t i;
+	if (now == gsr->last)
+		return ;
 
-	for (i=gsr->last; i<now ;)
-		gsr->l0[(i++) % gsr->period] = v;
-	gsr->last = now;
+	guint64 v = (gsr->flags & RRD_FLAG_SHIFT_SET) ? gsr->def : _rrd_current(gsr);
+	while (gsr->last != now) {
+		gsr->last ++;
+		_rrd_set(gsr,v);
+	}
 }
 
 void
-grid_single_rrd_push(struct grid_single_rrd_s *gsr, guint64 v)
+grid_single_rrd_push(struct grid_single_rrd_s *gsr, time_t now, guint64 v)
 {
-	time_t now;
+	_gsr_manage_timeshift(gsr, now);
+	_rrd_set(gsr, v);
+}
 
-	if ((now = time(0)) != gsr->last)
-		_gsr_blank_empty_slots(gsr, gsr->l0[gsr->last % gsr->period], now);
-
-	gsr->l0[now % gsr->period] = v;
-	gsr->last = now;
+void
+grid_single_rrd_pushifmax(struct grid_single_rrd_s *gsr, time_t now, guint64 v)
+{
+	_gsr_manage_timeshift(gsr, now);
+	guint64 v0 = _rrd_current(gsr);
+	_rrd_set(gsr, MAX(v0,v));
 }
 
 guint64
-grid_single_rrd_get(struct grid_single_rrd_s *gsr)
+grid_single_rrd_get(struct grid_single_rrd_s *gsr, time_t now)
 {
-	time_t now;
-
-	if ((now = time(0)) != gsr->last)
-		_gsr_blank_empty_slots(gsr, gsr->l0[gsr->last % gsr->period], now);
-
-	return gsr->l0[now % gsr->period];
+	_gsr_manage_timeshift(gsr, now);
+	return _rrd_current(gsr);
 }
 
 guint64
-grid_single_rrd_get_delta(struct grid_single_rrd_s *gsr, time_t period)
+grid_single_rrd_get_delta(struct grid_single_rrd_s *gsr,
+		time_t now, time_t period)
 {
-	time_t now;
-
 	EXTRA_ASSERT(period < gsr->period);
+	_gsr_manage_timeshift(gsr, now);
+	return _rrd_current(gsr) - _rrd_past(gsr, period);
+}
 
-	if ((now = time(0)) != gsr->last)
-		_gsr_blank_empty_slots(gsr, gsr->l0[gsr->last % gsr->period], now);
-
-	return gsr->l0[now % gsr->period] - gsr->l0[(now-period) % gsr->period];
+guint64
+grid_single_rrd_get_max(struct grid_single_rrd_s *gsr,
+		time_t now, time_t period)
+{
+	EXTRA_ASSERT(period < gsr->period);
+	_gsr_manage_timeshift(gsr, now);
+	guint64 maximum = 0;
+	for (time_t i=0; i<period ;i++) {
+		guint64 m = _rrd_past(gsr,i);
+		maximum = MAX(maximum,m);
+	}
+	return maximum;
 }
 
 void
-grid_single_rrd_feed(struct grid_stats_holder_s *gsh, ...)
+grid_single_rrd_get_allmax(struct grid_single_rrd_s *gsr,
+		time_t now, time_t period, guint64 *out)
+{
+	EXTRA_ASSERT(period < gsr->period);
+	_gsr_manage_timeshift(gsr, now);
+	guint64 maximum = 0;
+	for (time_t i=0; i<period ;i++) {
+		guint64 m = _rrd_past(gsr,i);
+		out[i] = maximum = MAX(maximum,m);
+	}
+}
+
+void
+grid_single_rrd_feed(struct grid_stats_holder_s *gsh, time_t now, ...)
 {
 	struct grid_single_rrd_s *gsr;
 	gchar *n;
 	va_list va;
-	time_t now;
 
 	EXTRA_ASSERT(gsh != NULL);
 
-	now = time(0);
-
-	va_start(va, gsh);
+	va_start(va, now);
 	g_mutex_lock(gsh->lock);
 	while (NULL != (n = va_arg(va, gchar*))) {
 		gsr = va_arg(va, struct grid_single_rrd_s*);
 		if (!gsr)
 			break;
-		if (now != gsr->last)
-			_gsr_blank_empty_slots(gsr, gsr->l0[gsr->last % gsr->period], now);
-		gsr->l0[now % gsr->period] = _real_get(gsh->hashset, n);
-		gsr->last = now;
+		_gsr_manage_timeshift(gsr, now);
+		_rrd_set(gsr, _real_get(gsh->hashset, n));
 	}
 	g_mutex_unlock(gsh->lock);
 	va_end(va);

--- a/server/stats_holder.h
+++ b/server/stats_holder.h
@@ -84,44 +84,48 @@ void grid_stats_holder_foreach(struct grid_stats_holder_s *gsh,
 
 /* ------------------------------------------------------------------------- */
 
-/*!
- * @param period
- * @return
- */
-struct grid_single_rrd_s* grid_single_rrd_create(time_t period);
+/*! Allocates a round-robin set of metrics, working on <period> slots. */
+struct grid_single_rrd_s* grid_single_rrd_create(time_t now, time_t period);
 
-/*!
- * @param gsr
- */
+/*! Cleans all the resources used by the rrd. */
 void grid_single_rrd_destroy(struct grid_single_rrd_s *gsr);
 
-/*!
- * @param gsr
- * @param v
- */
-void grid_single_rrd_push(struct grid_single_rrd_s *gsr, guint64 v);
+/*! Save a default value to be used for the slots where there is no
+ * activity. */
+void grid_single_rrd_set_default(struct grid_single_rrd_s *gsr,
+		guint64 def);
 
-/*!
- * @param gsr
- * @return
- */
-guint64 grid_single_rrd_get(struct grid_single_rrd_s *gsr);
+/*! forces an absolute value for the current position */
+void grid_single_rrd_push(struct grid_single_rrd_s *gsr,
+		time_t at, guint64 v);
 
-/*!
- * @param gsr
- * @param period
- * @return
- */
+/*! forces an absolute value for the current position */
+void grid_single_rrd_pushifmax(struct grid_single_rrd_s *gsr,
+		time_t at, guint64 v);
+
+/*! Get the value in the current slot of the rrd. */
+guint64 grid_single_rrd_get(struct grid_single_rrd_s *gsr, time_t at);
+
+/*! Compute the difference between the current value and the value that
+ * is <period> seconds old. */
 guint64 grid_single_rrd_get_delta(struct grid_single_rrd_s *gsr,
-		time_t period);
+		time_t at, time_t period);
 
-/*!
- * Lock internally acquired on 'gsh'
- *
+/*! Computes the maximal value among the set not older than <period> seconds. */
+guint64 grid_single_rrd_get_max(struct grid_single_rrd_s *gsr,
+		time_t at, time_t period);
+
+/*! Cumulates all the maximum values, for all the periods between
+ * 1 and the given <period>. Single run! */
+void grid_single_rrd_get_allmax(struct grid_single_rrd_s *gsr,
+		time_t at, time_t period, guint64 *out);
+
+/*! Lock internally acquired on 'gsh'
  * @param gsh
  * @param ... a NULL terminated sequence of (grid_single_rrd_s*, gchar*)
  */
-void grid_single_rrd_feed(struct grid_stats_holder_s *gsh, ...);
+void grid_single_rrd_feed(struct grid_stats_holder_s *gsh,
+		time_t now, ...);
 
 /** @} */
 

--- a/server/transport_http.c
+++ b/server/transport_http.c
@@ -19,16 +19,12 @@ struct transport_client_context_s
 	struct http_parser_s *parser;
 	struct http_request_s *request;
 	struct http_request_dispatcher_s *dispatcher;
-
-	struct timeval tv_start;
 };
 
 struct http_request_handler_s
 {
 	enum http_rc_e (*handler)(gpointer u,
 			struct http_request_s *request, struct http_reply_ctx_s *reply);
-	gchar stat_name_req[256];
-	gchar stat_name_time[256];
 };
 
 struct http_request_dispatcher_s
@@ -39,14 +35,15 @@ struct http_request_dispatcher_s
 
 struct req_ctx_s
 {
-	gboolean close_after_request;
-	struct timeval tv_parsed;
+	struct timespec tv_start, tv_parsed;
 
 	struct network_client_s *client;
 	struct network_transport_s *transport;
 	struct transport_client_context_s *context;
 	struct http_request_dispatcher_s *dispatcher;
 	struct http_request_s *request;
+
+	gboolean close_after_request;
 };
 
 static int http_notify_input(struct network_client_s *clt);
@@ -322,10 +319,6 @@ transport_http_build_dispatcher(gpointer u,
 	for (d=descr; d && d->name && d->handler ;d++) {
 		struct http_request_handler_s h;
 		h.handler = d->handler;
-		g_snprintf(h.stat_name_req, sizeof(h.stat_name_req),
-				"%s.%s", HTTP_STAT_PREFIX_REQ, d->name);
-		g_snprintf(h.stat_name_time, sizeof(h.stat_name_time),
-				"%s.%s", HTTP_STAT_PREFIX_TIME, d->name);
 		g_array_append_vals(dispatcher->requests, &h, 1);
 	}
 
@@ -358,7 +351,6 @@ transport_http_factory0(struct http_request_dispatcher_s *dispatcher,
 	client_context->dispatcher = dispatcher;
 	client_context->parser = http_parser_create();
 	client_context->request = http_request_create(client);
-	gettimeofday(&client_context->tv_start, NULL);
 
 	transport = &(client->transport);
 	transport->client_context = client_context;
@@ -385,11 +377,11 @@ sender(gpointer k, gpointer v, gpointer u)
 static void
 _access_log(struct req_ctx_s *r, gint status, gsize out_len)
 {
-	struct timeval tv_now, tv_diff0, tv_diff1;
+	struct timespec now, diff_total, diff_handler;
 
-	gettimeofday(&tv_now, NULL);
-	timersub(&r->tv_parsed, &r->context->tv_start, &tv_diff0);
-	timersub(&tv_now, &r->tv_parsed, &tv_diff1);
+	network_server_now(&now);
+	timespec_sub(&now, &r->tv_start, &diff_total);
+	timespec_sub(&now, &r->tv_parsed, &diff_handler);
 
 	GString *gstr = g_string_sized_new(256);
 	g_string_append(gstr, r->client->local_name);
@@ -398,8 +390,8 @@ _access_log(struct req_ctx_s *r, gint status, gsize out_len)
 
 	g_string_append_printf(gstr,
 			" %ld.%06ld %ld.%06ld %d %"G_GSIZE_FORMAT" %%s %%s",
-			tv_diff0.tv_sec, tv_diff0.tv_usec,
-			tv_diff1.tv_sec, tv_diff1.tv_usec,
+			diff_total.tv_sec, diff_total.tv_nsec / 1000,
+			diff_handler.tv_sec, diff_handler.tv_nsec / 1000,
 			status, out_len);
 
 	g_log("access", GRID_LOGLVL_INFO, gstr->str, r->request->cmd, r->request->req_uri);
@@ -547,7 +539,6 @@ http_manage_request(struct req_ctx_s *r)
 	};
 
 	finalized = FALSE;
-	gettimeofday(&r->tv_parsed, NULL);
 	headers = g_tree_new_full(hashstr_quick_cmpdata, NULL, NULL, g_free);
 	body.data = NULL;
 	body.len = 0;
@@ -652,6 +643,13 @@ http_notify_input(struct network_client_s *clt)
 		struct http_parsing_result_s rc = http_parse(parser, data, data_size);
 
 		if (rc.status == HPRC_SUCCESS) {
+
+			// Important times are now known.$
+			// First, the last chunk of data received
+			// Second, the moment the real treatment start ... i.e. now!
+			memcpy(&r.tv_start, &clt->time.evt_in, sizeof(r.tv_start));
+			network_server_now(&r.tv_parsed);
+
 			GError *err = http_manage_request(&r);
 
 			http_parser_reset(parser);


### PR DESCRIPTION
This patch provides the maximum number of active threads, and a round-robin storage for that information.
The granularity proposed is intervals of 1s over the past 30s, and intervals of 1 minute over the past 1 hour.
This data is used by the core server library to expose statistics, e.g.

```
server.thread.max.1 = 0
server.thread.max.5 = 1
server.thread.max.15 = 2
server.thread.max.30 = 2
server.thread.max.60 = 3
server.thread.max.300 = 3
server.thread.max.900 = 3
server.thread.max.3600 = 3
```

This patch also alters the accesslog format for gridd transports, and it is now unified with http transport.
An access log record now provides 2 treatment durations:
- the total time spent since the reception of the last buffer that completes the request
- the total treatment time, from the moment where a worker thread starts the request handling til the moment an answer is generated.
  The delta between both delays is the time spent in the internals queues of the process.

The patch divides in:
- server/stats_holder.\* :
  - drops the adherence to system time, the current timestamp is now received from the caller. This is necessary to manager counter with a granularity different than 1s.
  - New calls to compute the cumulative maximum
  - code simplification
- server/network_server.\* :
  - new round-robin stats now managed
  - new stats exposed.
  - precise monotonic clock used on thelast input
- server/transport_http.c :
  - useless variables removed.
  - accesslog format reviewed (timers printed : total time spent, time spent in queue)
- server/transport_gridd.c :
  - accesslog format reviewed (timers printed : total time spent, time spent in queue)
- sqlx/sqlx_service.c :
  - code adapted to match the lost "time adherence"

Change-Id: I248ae7a1937860e4062290e95b68465d7ec62821
