### PR TITLE
zk-bootstrap doesn't fail on an error on the root node.

### DIFF
--- a/tools/zk-bootstrap.py
+++ b/tools/zk-bootstrap.py
@@ -159,7 +159,10 @@ def main():
 
 	zookeeper.set_debug_level(zookeeper.LOG_LEVEL_INFO)
 	zh = zookeeper.init(cnxstr)
-	zookeeper.create(zh, PREFIX, '', acl_openbar, 0)
+	try:
+		zookeeper.create(zh, PREFIX, '', acl_openbar, 0)
+	except zookeeper.NodeExistsException:
+		pass
 	create_tree(zh, boot_tree())
 	init_namespace(zh, ns)
 	zookeeper.close(zh)


### PR DESCRIPTION
Change-Id: I8dfcb3622bc96f0af2356f96ba64f6edce99c065
