### PR TITLE
Storage policy cleaned, storage class explicit loading

### DIFF
--- a/metautils/lib/CMakeLists.txt
+++ b/metautils/lib/CMakeLists.txt
@@ -369,6 +369,11 @@ target_link_libraries(test_lb
 		metautils metacomm
 		${GLIB2_LIBRARIES})
 
+add_executable(test_stg_policy test_stg_policy.c)
+target_link_libraries(test_stg_policy
+		metautils 
+		${GLIB2_LIBRARIES})
+
 add_executable(test_svc_policy test_svc_policy.c)
 target_link_libraries(test_svc_policy
 		metautils 
@@ -480,6 +485,7 @@ install(FILES
 			OWNER_WRITE OWNER_READ GROUP_READ WORLD_READ)
 			
 
+add_test(NAME metautils/stgpol COMMAND test_stg_policy)
 add_test(NAME metautils/svc_policy COMMAND test_svc_policy)
 add_test(NAME metautils/lb COMMAND test_lb)
 add_test(NAME metautils/url COMMAND test_hc_url)

--- a/metautils/lib/storage_policy.h
+++ b/metautils/lib/storage_policy.h
@@ -97,6 +97,17 @@ const gchar *data_security_type_name(enum data_security_e type);
 const struct data_treatments_s *storage_policy_get_data_treatments(
 		const struct storage_policy_s *sp);
 
+/** Inits a storage class from scratch, with its namespace configuration. */
+struct storage_class_s * storage_class_init (struct namespace_info_s *ni,
+		const char *name);
+
+/** Frees all the internal memory used by the storage class pointed by <sc> */
+void storage_class_clean(struct storage_class_s *sc);
+
+/** Calls storage_class_clean() on <u> and ignores <ignored> */
+void storage_class_gclean(gpointer u, gpointer ignored);
+
+
 /**
  * @param sp
  * @return

--- a/metautils/lib/storage_policy_internals.h
+++ b/metautils/lib/storage_policy_internals.h
@@ -1,0 +1,36 @@
+#ifndef RC_metautils_storage_policy_internals__h
+# define RC_metautils_storage_policy_internals__h 1
+
+#include <glib.h>
+
+#include "storage_policy.h"
+
+struct data_security_s
+{
+	gchar *name;
+	enum data_security_e type;
+	GHashTable *params;
+};
+
+struct data_treatments_s
+{
+	gchar *name;
+	enum data_treatments_e type;
+	GHashTable *params;
+};
+
+struct storage_class_s
+{
+	gchar *name;
+	GSList *fallbacks;
+};
+
+struct storage_policy_s
+{
+	gchar *name;
+	struct data_security_s *datasec;
+	struct data_treatments_s *datatreat;
+	struct storage_class_s *stgclass;
+};
+
+#endif

--- a/metautils/lib/test_stg_policy.c
+++ b/metautils/lib/test_stg_policy.c
@@ -1,0 +1,106 @@
+#ifndef G_LOG_DOMAIN
+# define G_LOG_DOMAIN "metautils.test"
+#endif
+
+#include <metautils/lib/metautils.h>
+#include <metautils/lib/storage_policy.h>
+#include <metautils/lib/storage_policy_internals.h>
+
+static void
+_init_ns (struct namespace_info_s *ni)
+{
+	gchar *s = g_strdup_printf(
+			"{"
+				"\"ns\":\"%s\","
+					"\"chunksize\":%i,"
+					"\"writable_vns\":[\"%s.VNS0\",\"%s.VNS1\"],"
+					"\"storage_policy\":{"
+					"\"rain32\":\"NONE:RAIN32:NONE\","
+					"\"dupli3\":\"NONE:DUPLI3:NONE\","
+					"\"classic\":\"NONE:DUPONETWO:NONE\","
+					"\"polcheck\":\"NONE:DUPONETHREE:SIMCOMP\","
+					"\"secure\":\"NONE:DUP_SECURE:NONE\""
+				"},"
+				"\"data_security\":{"
+					"\"DUPLI3\":\"DUP:distance=0|nb_copy=3\","
+					"\"RAIN32\":\"RAIN:distance=0|k=3|m=2\","
+					"\"DUPONETWO\":\"DUP:distance=1|nb_copy=2\","
+					"\"DUPONETHREE\":\"DUP:distance=1|nb_copy=3\","
+					"\"DUP_SECURE\":\"DUP:distance=4|nb_copy=2\""
+				"},"
+				"\"data_treatments\":{"
+					"\"SIMCOMP\":\"COMP:algo=ZLIB|blocksize=262144\""
+				"},"
+				"\"storage_class\":{"
+					"\"GOLD\":\"SILVER:BRONZE:CLAY\","
+					"\"SILVER\":\"BRONZE:CLAY\","
+					"\"BRONZE\":\"CLAY\","
+					"\"CLAY\":\"\""
+				"},"
+				"\"options\":{"
+				"}"
+			"}", "NS", 1024, "NS", "NS");
+
+	memset(ni, 0, sizeof(struct namespace_info_s));
+	namespace_info_reset(ni);
+	GError *err = namespace_info_init_json(s, ni);
+	g_assert_no_error(err);
+	g_free(s);
+}
+
+static void
+test_stgclass_no_fallback ()
+{
+	struct namespace_info_s ni;
+	_init_ns(&ni);
+
+	struct storage_class_s *sc = storage_class_init(&ni, "CLAY");
+	g_assert(sc != NULL);
+	g_assert(0 == g_slist_length(sc->fallbacks));
+	storage_class_clean(sc);
+
+	namespace_info_clear(&ni);
+}
+
+static void
+test_stgclass_with_fallback ()
+{
+	struct namespace_info_s ni;
+	_init_ns(&ni);
+
+	struct storage_class_s *sc = storage_class_init(&ni, "SILVER");
+	g_assert(sc != NULL);
+	g_assert(2 == g_slist_length(sc->fallbacks));
+	g_assert(0 == strcmp("BRONZE", (gchar*) g_slist_nth_data(sc->fallbacks, 0)));
+	g_assert(0 == strcmp("CLAY", (gchar*) g_slist_nth_data(sc->fallbacks, 1)));
+	storage_class_clean(sc);
+
+	namespace_info_clear(&ni);
+}
+
+#if 0
+static void
+test_datasec ()
+{
+	// @todo TODO Not yet implemented
+}
+
+static void
+test_stgpol ()
+{
+	// @todo TODO Not yet implemented
+}
+#endif
+
+int
+main(int argc, char **argv)
+{
+	HC_TEST_INIT(argc,argv);
+	g_test_add_func("/metautils/stgclass/with_fallback", test_stgclass_with_fallback);
+	g_test_add_func("/metautils/stgclass/no_fallback", test_stgclass_no_fallback);
+#if 0
+	g_test_add_func("/metautils/datasec", test_datasec);
+	g_test_add_func("/metautils/stgpol", test_stgpol);
+#endif
+	return g_test_run();
+}

--- a/metautils/lib/utils_namespace_info.c
+++ b/metautils/lib/utils_namespace_info.c
@@ -269,9 +269,10 @@ namespace_info_get_storage_class(namespace_info_t *ni, const gchar *stgclass_key
 	if (ni->storage_class != NULL) {
 		GByteArray *gba = NULL;
 		gba = g_hash_table_lookup(ni->storage_class, stgclass_key);
-		if (gba != NULL) {
+		if (!gba->data || gba->len <= 0)
+			return g_strdup("");
+		if (gba != NULL)
 			return g_strndup((gchar*)gba->data, gba->len);
-		}
 	}
 	return NULL;
 }


### PR DESCRIPTION
Now able to load a storage class explicitely, out of any storage policy context.

This is necessary for the metacd-http to process load-balancing requests with stgclass constraints. In facts, the metacd_http simply wraps the calls to metautils/lib/lb.h API.

Also, stgpol-related structures have been exposed in a nearly-hidden header, for testing purposes.
A corner case where a storage policy should exist but have no fallback has been fixed in the gridcluster configuration.
Finally, functions have been reordered "by purpose".

Change-Id: Ibd66594d53666f5ca4d1fab6d4226e1dc17ba95d
