### PR TITLE
service_info unique key getter.

### DIFF
--- a/metautils/lib/metatype_srvinfo.h
+++ b/metautils/lib/metatype_srvinfo.h
@@ -381,6 +381,9 @@ GError* service_info_load_json(const gchar *encoded,
 // Appends to 'out' a json representation of 'si'
 void service_info_encode_json(GString *out, struct service_info_s *si);
 
+/* Returns a unique key identifying the service */
+gchar * service_info_key (const struct service_info_s *si);
+
 /** @} */
 
 #endif // __REDCURRANT_metatype_srvinfo__h

--- a/metautils/lib/utils_service_info.c
+++ b/metautils/lib/utils_service_info.c
@@ -681,6 +681,20 @@ service_info_is_internal(const struct service_info_s *si)
 	            NAME_TAGNAME_INTERNAL, "false")));
 }
 
+gchar *
+service_info_key (const struct service_info_s *si)
+{
+	gchar ns[LIMIT_LENGTH_NSNAME], addr[STRLEN_ADDRINFO];
+	metautils_strlcpy_physical_ns(ns, si->ns_name, sizeof(ns));
+
+	const gchar *explicit = service_info_get_tag_value(si, "tag.id", NULL);
+	if (explicit)
+		return g_strdup_printf("%s|%s|%s", ns, si->type, explicit);
+
+	grid_addrinfo_to_string(&si->addr, addr, sizeof(addr));
+	return g_strdup_printf("%s|%s|%s", ns, si->type, addr);
+}
+
 //------------------------------------------------------------------------------
 
 static void


### PR DESCRIPTION
First step of the plan toward services identified with a logical ID, instead of an IP:PORT couple.

Change-Id: Iebd9484e53d20877ee5a16192d78e1feeba30dac
