### PR TITLE
Load-balancing cleanup.

### DIFF
--- a/integrity/lib/content_check.c
+++ b/integrity/lib/content_check.c
@@ -172,7 +172,7 @@ _find_matching_rawx(GSList *rawx, GSList *used_loc, gint64 distance,
 		}
 
 		/* check rawx has appropriate storage class (strictly) */
-		if (!grid_lb_check_storage_class(stg_class, l->data)) {
+		if (!service_info_check_storage_class(l->data, stg_class)) {
 			GRID_DEBUG(MSG_DONT_MATCH_CRITERIA, "storage class");
 			continue;
 		}
@@ -869,7 +869,7 @@ _check_duplicated_content_is_valid(struct meta2_ctx_s *ctx)
 		}
 
 		/* check chunk storage class */
-		if (!grid_lb_check_storage_class(storage_class_get_name(stg_class), si)) {
+		if (!service_info_check_storage_class(si, storage_class_get_name(stg_class))) {
 			GRID_INFO("Wrong storage class for %s: expected '%s'",
 					chunk_str, storage_class_get_name(stg_class));
 			/* Add the chunk to the "almost good" list. These

--- a/metautils/lib/lb.h
+++ b/metautils/lib/lb.h
@@ -9,6 +9,8 @@
 struct namespace_info_s;
 struct service_info_s;
 struct addr_info_s;
+struct json_object;
+
 
 /**
  * @defgroup metautils_lb Load-Balancing
@@ -18,102 +20,65 @@ struct addr_info_s;
 
 /* Service pool features ---------------------------------------------------- */
 
-/*!
- * A hidden structure representing a pool for a given service type.
- */
+/*! A hidden structure representing a pool for a given service type. */
 struct grid_lb_s;
 
-/*!
- * thread-safe structure managing several service pools, and holding the
- * load-balancing policies.
- */
+/*! thread-safe structure managing several service pools, and holding the
+ * load-balancing policies. */
 struct grid_lbpool_s;
 
-/*!
- * A way to iterate on services from a mono-type pool.
- */
+/*! A way to iterate on services from a mono-type pool. */
 struct grid_lb_iterator_s;
 
-/*! Used to iterate over service_info while reloading the pool.
- *
- * @param p_si
- * @return
- */
+/*! Used to iterate over service_info while reloading the pool. */
 typedef gboolean (*service_provider_f) (struct service_info_s **p_si);
+
 
 /* Mono-service pool features ---------------------------------------------- */
 
-void grid_lb_set_SD_shortening(struct grid_lb_s *lb, gboolean on);
-
-void grid_lb_set_shorten_ratio(struct grid_lb_s *lb, gdouble ratio);
-
-/*! Create a service pool ready to work
- *
- * @param ns
- * @param srvtype
- * @return
- */
+/*! Create a service pool ready to work */
 struct grid_lb_s* grid_lb_init(const gchar *ns, const gchar *srvtype);
 
-/*! Sets a hook to be called each time a resource is got from the
- * load-balancer. This helps providing lazy/timeout (re)loading.
- *
- * @param lb
- * @param use_hook
- */
-void grid_lb_set_use_hook(struct grid_lb_s *lb, void (*use_hook)(void));
-
-/*! frees the structure and all ots components. lb is invalid after.
- *
- * @param lb
- */
+/*! frees the structure and all ots components. lb is invalid after. */
 void grid_lb_clean(struct grid_lb_s *lb);
 
+/*! Configures the standard-deviation shortening. Shortens to the index where
+ * the service's score is the average + standard deviation. When several
+ * shortenings are configured, the strongest is taken into consideration. */
+void grid_lb_set_SD_shortening(struct grid_lb_s *lb, gboolean on);
+
+/*! Configures the fixed-ratio shortening. When several shortenings are
+ * configured, the strongest is taken into consideration. */
+void grid_lb_set_shorten_ratio(struct grid_lb_s *lb, gdouble ratio);
+
+/*! Sets a hook to be called each time a resource is got from the
+ * load-balancer. This helps providing lazy/timeout (re)loading. */
+void grid_lb_set_use_hook(struct grid_lb_s *lb, void (*use_hook)(void));
+
 /*! Internally calls a flush then feeds all the services coming
- * out of the provider hook.
- *
- * @param lb
- * @param provide
- */
+ * out of the provider hook. */
 void grid_lb_reload(struct grid_lb_s *lb, service_provider_f provide);
 
-struct json_object;
-
+/*! Reloads the pool with the given JSON services. */
 GError*  grid_lb_reload_json_object(struct grid_lb_s *lb,
 		struct json_object *obj);
 
+/*! Reloads the pool with the given JSON encoded services. */
 GError*  grid_lb_reload_json(struct grid_lb_s *lb, const gchar *encoded);
 
-/**
- * @param lb not NULL
- * @return the number of elements in the given pool, after shorten ratio.
- */
+/*! Returns the number of elements in the given pool, after shorten ratio. */
 gsize grid_lb_count(struct grid_lb_s *lb);
 
-/**
- * @param lb not NULL
- * @return the number of elements in the given pool.
- */
+/** Returns the number of elements in the given pool. */
 gsize grid_lb_count_all(struct grid_lb_s *lb);
 
 /*! Tests if a service is still available. Unavailable means either
  * absent, a score less or equal to zero. This function performs
- * a check on the service type.
- *
- * @param lb
- * @param si
- * @return
- */
+ * a check on the service type. */
 gboolean grid_lb_is_srv_available(struct grid_lb_s *lb,
 		const struct service_info_s *si);
 
-/*! Idem for a given service
- *
- * @see grid_lb_is_srv_available()
- * @param lb
- * @param ai
- * @return
- */
+/*! Idem for a given service. @see grid_lb_is_srv_available() */
 gboolean grid_lb_is_addr_available(struct grid_lb_s *lb,
 		const struct addr_info_s *ai);
 
@@ -123,63 +88,11 @@ struct service_info_s* grid_lb_get_service_from_url(struct grid_lb_s *lb,
 struct service_info_s* grid_lb_get_service_from_addr(struct grid_lb_s *lb,
 		const struct addr_info_s *ai);
 
+/*! Reconfigures the pool, Acquires/Releases the lock on pool. */
+void grid_lb_configure_options(struct grid_lb_s *lb, const gchar *opts);
+
+
 /* Iterators features ------------------------------------------------------ */
-
-/*!
- * @param lb
- */
-struct grid_lb_iterator_s* grid_lb_iterator_single_run(struct grid_lb_s *lb);
-
-/*!
- * @param lb
- * @return
- */
-struct grid_lb_iterator_s* grid_lb_iterator_round_robin(
-		struct grid_lb_s *lb);
-
-/*!
- * @param lb
- * @return
- */
-struct grid_lb_iterator_s* grid_lb_iterator_weighted_round_robin(
-		struct grid_lb_s *lb);
-
-/*!
- * @param lb
- * @return
- */
-struct grid_lb_iterator_s* grid_lb_iterator_scored_round_robin(
-		struct grid_lb_s *lb);
-
-/*!
- * @param lb
- * @return
- */
-struct grid_lb_iterator_s* grid_lb_iterator_random(struct grid_lb_s *lb);
-
-/*!
- * @param lb
- * @return
- */
-struct grid_lb_iterator_s* grid_lb_iterator_weighted_random(
-		struct grid_lb_s *lb);
-
-/*!
- * @param lb
- * @return
- */
-struct grid_lb_iterator_s* grid_lb_iterator_scored_random(
-		struct grid_lb_s *lb);
-
-typedef gboolean (*service_filter) (struct service_info_s *si, gpointer hook_data);
-
-/*! Build an iterator based on another iterator. The concurrency is managed
- * internally.
- *
- * @param main
- * @return
- */
-struct grid_lb_iterator_s* grid_lb_iterator_share(struct grid_lb_iterator_s *i);
 
 /*!
  * If no type is provided, the default is choosen (RR).
@@ -188,10 +101,10 @@ struct grid_lb_iterator_s* grid_lb_iterator_share(struct grid_lb_iterator_s *i);
  * - SINGLE : simple iterator, run the services once
  * - RR (default) : simple round-robin
  * - WRR : weighted round-robin (using the service's weight)
- * - SRR : weighted round-robin (using the service's score)
+ * - SRR : synonym for WRR
  * - RAND : simple random pick
  * - WRAND : weighted random-pick (using the service's weight)
- * - SRAND : weighted random-pick (using the service's score)
+ * - SRAND : synonym for WRAND
  *
  * @param lb
  * @param type
@@ -199,6 +112,48 @@ struct grid_lb_iterator_s* grid_lb_iterator_share(struct grid_lb_iterator_s *i);
  */
 struct grid_lb_iterator_s* grid_lb_iterator_init(struct grid_lb_s *lb,
 		const gchar *type);
+
+/*! @see grid_lb_iterator_init() */
+struct grid_lb_iterator_s* grid_lb_iterator_single_run(struct grid_lb_s *lb);
+
+/*! @see grid_lb_iterator_init() */
+struct grid_lb_iterator_s* grid_lb_iterator_round_robin(struct grid_lb_s *lb);
+
+/*! @see grid_lb_iterator_init() */
+struct grid_lb_iterator_s* grid_lb_iterator_weighted_round_robin(struct grid_lb_s *lb);
+
+/*! @see grid_lb_iterator_init() */
+struct grid_lb_iterator_s* grid_lb_iterator_random(struct grid_lb_s *lb);
+
+/*! @see grid_lb_iterator_init() */
+struct grid_lb_iterator_s* grid_lb_iterator_weighted_random(struct grid_lb_s *lb);
+
+/*! Build an iterator based on another iterator. The concurrency is managed
+ * internally. */
+struct grid_lb_iterator_s* grid_lb_iterator_share(struct grid_lb_iterator_s *i);
+
+/*! Clean the iterator and all its internals structures */
+void grid_lb_iterator_clean(struct grid_lb_iterator_s *iter);
+
+/*! @see grid_lb_configure_options() */
+void grid_lb_iterator_configure(struct grid_lb_iterator_s *iter,
+		const gchar *val);
+
+/*!  */
+gboolean grid_lb_iterator_is_srv_available(struct grid_lb_iterator_s *iter,
+		const struct service_info_s *si);
+
+/*!  */
+gboolean grid_lb_iterator_is_addr_available(struct grid_lb_iterator_s *iter,
+		const struct addr_info_s *ai);
+
+/*!  */
+gboolean grid_lb_iterator_is_url_available(struct grid_lb_iterator_s *iter,
+		const gchar *url);
+
+/* Polling ----------------------------------------------------------------- */
+
+typedef gboolean (*service_filter) (struct service_info_s *si, gpointer hook_data);
 
 /*! Get the next service from the iterator.
  * @see service_info_clean()
@@ -282,124 +237,62 @@ struct lb_next_opt_ext_s
 gboolean grid_lb_iterator_next_set(struct grid_lb_iterator_s *iter,
 		struct service_info_s ***si, struct lb_next_opt_s *opt);
 
+/*! @see grid_lb_iterator_next_set() */
 gboolean grid_lb_iterator_next_set2(struct grid_lb_iterator_s *iter,
 		struct service_info_s ***si, struct lb_next_opt_ext_s *opt);
 
-/*!
- * @param iter
- * @param si
- * @return
- */
-gboolean grid_lb_iterator_is_srv_available(struct grid_lb_iterator_s *iter,
-		const struct service_info_s *si);
-
-/*!
- * @param iter
- * @param ai
- * @return
- */
-gboolean grid_lb_iterator_is_addr_available(struct grid_lb_iterator_s *iter,
-		const struct addr_info_s *ai);
-
-/*!
- * @param iter
- * @param url
- * @return
- */
-gboolean grid_lb_iterator_is_url_available(struct grid_lb_iterator_s *iter,
-		const gchar *url);
-
-/*! Clean the iterator and all its internals structures
- *
- * @param iter
- */
-void grid_lb_iterator_clean(struct grid_lb_iterator_s *iter);
-
-/*!
- * Tests if the storage class of a service complies with
- * a specific storage class.
- *
- * @param wanted_class The class we want to match to
- * @param si The service description
- * @param strict If false, accept equivalent storage classes
- * @return TRUE if storage class match, FALSE otherwise
- */
-gboolean grid_lb_check_storage_class(const gchar *wanted_class,
-		struct service_info_s *si);
-
-/*!
- * @param iter
- * @param val
- */
-void grid_lb_iterator_configure(struct grid_lb_iterator_s *iter,
-		const gchar *val);
-
-/**
- * @param opts
- * @param lb
- */
-void grid_lb_configure_options(struct grid_lb_s *lb, const gchar *opts);
 
 /* Multi-services pool features --------------------------------------------- */
 
-const gchar* grid_lbpool_namespace(struct grid_lbpool_s *glp);
-
-/*!
- * Create a lbpool ready to use
- * @param ns Not NULL
- */
+/*! Create a lbpool ready to use (no service declared). */
 struct grid_lbpool_s* grid_lbpool_create(const gchar *ns);
 
-/*!
- * Frees the memory used by the lbpool
- * @param glp no-op if NULL
- */
+/*! Frees the memory used by the lbpool */
 void grid_lbpool_destroy(struct grid_lbpool_s *glp);
 
-/*!
- * Ensure the type is managed and configures it if special configuration is
- * present in the conscience configuration.
- *
- * @param glp
- * @param ni
- */
+/*! Returns the NS name associated to this pool. */
+const gchar* grid_lbpool_namespace(struct grid_lbpool_s *glp);
+
+/*! Ensure each type is managed according to the NS configuration. */
 void grid_lbpool_reconfigure(struct grid_lbpool_s *glp,
 		struct namespace_info_s *ni);
 
-/**
- * @param glp
- * @param srvtype
- * @param cfg
- */
+/*! Ensure the type is managed according to the given configuration */
 void grid_lbpool_configure_string(struct grid_lbpool_s *glp,
 		const gchar *srvtype, const gchar *cfg);
 
-/*!
- * @see grid_lb_reload()
- * @param glp
- * @param srvtype
- * @param provider
- */
+/*! Ensure the type is managed (pool+iterator) abd return the pool. */
+struct grid_lb_s * grid_lbpool_ensure_lb (struct grid_lbpool_s *glp,
+		const gchar *srvtype);
+
+/*! Returns the pool for the given type, or NULL if unknown */
+struct grid_lb_s * grid_lbpool_get_lb (struct grid_lbpool_s *glp,
+		const gchar *srvtype);
+
+/*! Ensure the type is managed (pool+iterator) abd return the iterator. */
+struct grid_lb_iterator_s * grid_lbpool_ensure_iterator (
+		struct grid_lbpool_s *glp, const gchar *srvtype);
+
+/*! Return the iterator for the given type, if managed (or NULL otherwise) */
+struct grid_lb_iterator_s* grid_lbpool_get_iterator(
+		struct grid_lbpool_s *glp, const gchar *srvtype);
+
+/*! @see grid_lb_reload() */
 void grid_lbpool_reload(struct grid_lbpool_s *glp, const gchar *srvtype,
 		service_provider_f provider);
 
+/*! @see grid_lb_reload() */
 GError* grid_lbpool_reload_json_object(struct grid_lbpool_s *glp, const gchar *srvtype,
 		struct json_object *obj);
 
+/*! @see grid_lb_reload() */
 GError* grid_lbpool_reload_json(struct grid_lbpool_s *glp, const gchar *srvtype,
 		const gchar *encoded);
 
-/**
- * @param glp
- * @param srvtype
- * @return
- */
-struct grid_lb_iterator_s* grid_lbpool_get_iterator(struct grid_lbpool_s *glp,
-		const gchar *srvtype);
-
+/*!  */
 struct service_info_s* grid_lbpool_get_service_from_url(
-struct grid_lbpool_s *glp,
-		const gchar *srvtype, const gchar *url);
+		struct grid_lbpool_s *glp, const gchar *srvtype,
+		const gchar *url);
 
 /*! @} */
 

--- a/metautils/lib/metatype_srvinfo.h
+++ b/metautils/lib/metatype_srvinfo.h
@@ -355,6 +355,18 @@ const gchar * service_info_get_rawx_volume(const struct service_info_s *si,
 const gchar * service_info_get_stgclass(const struct service_info_s *si,
 		const gchar *def);
 
+/*!
+ * Tests if the storage class of a service complies with
+ * a specific storage class.
+ *
+ * @param wanted_class The class we want to match to
+ * @param si The service description
+ * @param strict If false, accept equivalent storage classes
+ * @return TRUE if storage class match, FALSE otherwise
+ */
+gboolean service_info_check_storage_class(const struct service_info_s *si,
+		const gchar *wanted_class);
+
 /**
  * Check if a service_info is specified as internal (i.e. if it has a tag "tag.internal"
  * with a string value not equals to "false"

--- a/metautils/lib/metautils_containers.h
+++ b/metautils/lib/metautils_containers.h
@@ -23,12 +23,13 @@ GPtrArray* metautils_list_to_gpa(GSList *orig);
  */
 GSList* metautils_gpa_to_list(GPtrArray *gpa);
 
-/**
- * @param orig
- * @return
- */
+/** Convert an array of pointer to a signly linked list, omitting the last
+ * NULL beacon. */
 GSList* metautils_array_to_list(void **orig);
 
+void** metautils_gpa_to_array(GPtrArray *orig, gboolean clean);
+
+GPtrArray* metautils_gtree_to_gpa(GTree *t, gboolean clean);
 
 GSList * metautils_gslist_shuffle(GSList *src);
 

--- a/metautils/lib/test_lb.c
+++ b/metautils/lib/test_lb.c
@@ -306,19 +306,6 @@ test_lb_WRR(void)
 }
 
 static void
-test_lb_SRR(void)
-{
-	struct grid_lb_s *lb;
-	struct grid_lb_iterator_s *iter;
-
-	lb = _build();
-	iter = grid_lb_iterator_scored_round_robin(lb);
-	check_service_count(iter);
-	grid_lb_iterator_clean(iter);
-	grid_lb_clean(lb);
-}
-
-static void
 test_lb_RAND(void)
 {
 	struct grid_lb_s *lb;
@@ -347,20 +334,6 @@ test_lb_WRAND(void)
 	grid_lb_clean(lb);
 }
 
-static void
-test_lb_SRAND(void)
-{
-	struct grid_lb_s *lb;
-	struct grid_lb_iterator_s *iter;
-
-	lb = _build();
-	iter = grid_lb_iterator_scored_random(lb);
-	grid_lb_iterator_configure(iter, "shorten_ratio=0.9&standard_deviation=on");
-	check_service_count(iter);
-	grid_lb_iterator_clean(iter);
-	grid_lb_clean(lb);
-}
-
 /* -------------------------------------------------------------------------- */
 
 static void
@@ -378,9 +351,7 @@ main(int argc, char **argv)
 {
 	HC_TEST_INIT(argc,argv);
 	g_test_add_func("/grid/lb/WRAND", test_lb_WRAND);
-	g_test_add_func("/grid/lb/SRAND", test_lb_SRAND);
 	g_test_add_func("/grid/lb/RAND", test_lb_RAND);
-	g_test_add_func("/grid/lb/SRR", test_lb_SRR);
 	g_test_add_func("/grid/lb/WRR", test_lb_WRR);
 	g_test_add_func("/grid/lb/RR", test_lb_RR);
 	g_test_add_func("/grid/pool/create_destroy", test_pool_create_destroy);

--- a/metautils/lib/utils_containers.c
+++ b/metautils/lib/utils_containers.c
@@ -142,9 +142,21 @@ metautils_list_to_gpa(GSList *orig)
 }
 
 void**
+metautils_gpa_to_array(GPtrArray *orig, gboolean clean)
+{
+	if (!orig)
+		return NULL;
+	if (orig->len <= 0)
+		return g_malloc0(sizeof(void**));
+	if (NULL != orig->pdata[ orig->len - 1 ])
+		g_ptr_array_add(orig, NULL);
+	return clean ? g_ptr_array_free(orig, FALSE) : orig->pdata;
+}
+
+void**
 metautils_list_to_array(GSList *orig)
 {
-	return g_ptr_array_free(metautils_list_to_gpa(orig), FALSE);
+	return metautils_gpa_to_array(metautils_list_to_gpa(orig), TRUE);
 }
 
 GSList*
@@ -213,5 +225,20 @@ g_slist_agregate(GSList * list, GCompareFunc comparator)
 
 	g_slist_free (sorted);
 	return g_slist_reverse(resL2);
+}
+
+GPtrArray*
+metautils_gtree_to_gpa(GTree *t, gboolean clean)
+{
+	gboolean run_move(gpointer k, gpointer v, gpointer u) {
+		(void) k;
+		g_ptr_array_add(u, v);
+		return FALSE;
+	}
+	GPtrArray *tmp = g_ptr_array_new();
+	g_tree_foreach(t, run_move, tmp);
+	if (clean)
+		g_tree_destroy(t);
+	return tmp;
 }
 

--- a/metautils/lib/utils_service_info.c
+++ b/metautils/lib/utils_service_info.c
@@ -681,6 +681,14 @@ service_info_is_internal(const struct service_info_s *si)
 	            NAME_TAGNAME_INTERNAL, "false")));
 }
 
+gboolean
+service_info_check_storage_class(const struct service_info_s *si, const gchar *wanted_class)
+{
+	const gchar *actual_class = service_info_get_tag_value(si,
+			NAME_TAGNAME_RAWX_STGCLASS, NULL);
+	return storage_class_is_satisfied(wanted_class, actual_class);
+}
+
 gchar *
 service_info_key (const struct service_info_s *si)
 {


### PR DESCRIPTION
The starting point of this patch was allowing a caller (i.e. the metacd_http) to use an iterator different than those specified in the NS configuration. In other words, to thinly wrap the API.

Some code reorganisation took place:
- function reordering (to be grouped by puposes)
- obsoletes removals (scored iterators ... meaningless since the score is the weight).
- functions moved in others modules (checks on the storage class of services, moved into service_info)
- code factorized (minor container handling, in metautils_containers)

Change-Id: I625fd9413e0fa01d68d085f93160c026b9744c0f
